### PR TITLE
fixup: add git safe.directory to Dockerfile

### DIFF
--- a/redhat/overlays/Dockerfile.tuf-server
+++ b/redhat/overlays/Dockerfile.tuf-server
@@ -1,6 +1,8 @@
 # Build the tuf server binary
 FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
 WORKDIR /tuf-server
+RUN git config --global --add safe.directory /tuf-server
+
 COPY . .
 USER root
 RUN make build-tuf-server


### PR DESCRIPTION
This is needed for builds to complete successfully in RHTAP