### PR TITLE
chore: add Dockerfiles for most scaffolding images

### DIFF
--- a/redhat/overlays/Dockerfile.cloudsqlproxy
+++ b/redhat/overlays/Dockerfile.cloudsqlproxy
@@ -1,0 +1,22 @@
+# Build the cloudsqlproxy binary
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+WORKDIR /cloudsqlproxy
+RUN git config --global --add safe.directory /cloudsqlproxy
+
+COPY . .
+USER root
+RUN make build-cloudsqlproxy
+
+# Install server
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+COPY --from=build-env /cloudsqlproxy/cloudsqlproxy /usr/local/bin/cloudsqlproxy
+RUN chown root:0 /usr/local/bin/cloudsqlproxy && chmod g+wx /usr/local/bin/cloudsqlproxy
+
+#Configure home directory
+ENV HOME=/home
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+
+WORKDIR ${HOME}
+
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/user/local/bin/cloudsqlproxy"]

--- a/redhat/overlays/Dockerfile.createcerts
+++ b/redhat/overlays/Dockerfile.createcerts
@@ -1,0 +1,22 @@
+# Build the createcerts binary
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+WORKDIR /createcerts
+RUN git config --global --add safe.directory /createcerts
+
+COPY . .
+USER root
+RUN make build-fulcio-createcerts
+
+# Install server
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+COPY --from=build-env /createcerts/createcerts /usr/local/bin/createcerts
+RUN chown root:0 /usr/local/bin/createcerts && chmod g+wx /usr/local/bin/createcerts
+
+#Configure home directory
+ENV HOME=/home
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+
+WORKDIR ${HOME}
+
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/user/local/bin/createcerts"]

--- a/redhat/overlays/Dockerfile.createconfig
+++ b/redhat/overlays/Dockerfile.createconfig
@@ -1,0 +1,22 @@
+# Build the createconfig binary
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+WORKDIR /createconfig
+RUN git config --global --add safe.directory /createconfig
+
+COPY . .
+USER root
+RUN make build-ctlog-createconfig
+
+# Install server
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+COPY --from=build-env /createconfig/createconfig /usr/local/bin/createconfig
+RUN chown root:0 /usr/local/bin/createconfig && chmod g+wx /usr/local/bin/createconfig
+
+#Configure home directory
+ENV HOME=/home
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+
+WORKDIR ${HOME}
+
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/user/local/bin/createconfig"]

--- a/redhat/overlays/Dockerfile.createdb
+++ b/redhat/overlays/Dockerfile.createdb
@@ -1,0 +1,22 @@
+# Build the createdb binary
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+WORKDIR /createdb
+RUN git config --global --add safe.directory /createdb
+
+COPY . .
+USER root
+RUN make build-trillian-createdb
+
+# Install server
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+COPY --from=build-env /createdb/createdb /usr/local/bin/createdb
+RUN chown root:0 /usr/local/bin/createdb && chmod g+wx /usr/local/bin/createdb
+
+#Configure home directory
+ENV HOME=/home
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+
+WORKDIR ${HOME}
+
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/user/local/bin/createdb"]

--- a/redhat/overlays/Dockerfile.createtree
+++ b/redhat/overlays/Dockerfile.createtree
@@ -1,0 +1,22 @@
+# Build the createtree binary
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+WORKDIR /createtree
+RUN git config --global --add safe.directory /createtree
+
+COPY . .
+USER root
+RUN make build-trillian-createtree
+
+# Install server
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+COPY --from=build-env /createtree/createtree /usr/local/bin/createtree
+RUN chown root:0 /usr/local/bin/createtree && chmod g+wx /usr/local/bin/createtree
+
+#Configure home directory
+ENV HOME=/home
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+
+WORKDIR ${HOME}
+
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/user/local/bin/createtree"]


### PR DESCRIPTION
This commit adds named Dockerfiles in the redhat/overlays directory in order to enable building the images in RHTAP.