### PR TITLE
Added new changes to the ct-server dockerfile as it as not building

### DIFF
--- a/redhat/overlays/Dockerfile.ct-server
+++ b/redhat/overlays/Dockerfile.ct-server
@@ -1,12 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
 USER root
 WORKDIR /ct_server
-RUN ls -a
 RUN git config --global --add safe.directory /ct_server
 ADD https://github.com/google/certificate-transparency-go/archive/refs/tags/v1.1.6.tar.gz /ct_server/
-RUN ls -a
 RUN tar -zxvf v1.1.6.tar.gz
-RUN ls -a 
 WORKDIR /ct_server/certificate-transparency-go-1.1.6/trillian/ctfe/ct_server
 RUN go build ./
 

--- a/redhat/overlays/Dockerfile.ct-server
+++ b/redhat/overlays/Dockerfile.ct-server
@@ -1,8 +1,12 @@
 FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+USER root
 WORKDIR /ct_server
-RUN git config --global --add safe.directory 
-RUN curl https://github.com/google/certificate-transparency-go/archive/refs/tags/v1.1.6.tar.gz  -L -o /ct_server/v1.1.6/tar.gz
-RUN tar -xvf v1.1.6.tar.gz
+RUN ls -a
+RUN git config --global --add safe.directory /ct_server
+ADD https://github.com/google/certificate-transparency-go/archive/refs/tags/v1.1.6.tar.gz /ct_server/
+RUN ls -a
+RUN tar -zxvf v1.1.6.tar.gz
+RUN ls -a 
 WORKDIR /ct_server/certificate-transparency-go-1.1.6/trillian/ctfe/ct_server
 RUN go build ./
 


### PR DESCRIPTION
Attempted to onboard this image this morning had some errors with building due to the Curl command not being installed on the builder layer image, However Dockerfiles allow for use of the ADD command which did basically the same thing and pulls down the correct tar file.

Also a small change of adding the correct directory to the git config.