### PR TITLE
chore: add patchfile to ignore update-to-head.sh

### DIFF
--- a/redhat/patches/0001-shellcheck.patch
+++ b/redhat/patches/0001-shellcheck.patch
@@ -1,0 +1,13 @@
+diff --git a/.github/workflows/verify.yml b/.github/workflows/verify.yml
+index ea9a9cf..0f63ccb 100644
+--- a/.github/workflows/verify.yml
++++ b/.github/workflows/verify.yml
+@@ -33,6 +33,8 @@ jobs:
+       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+       - name: Run ShellCheck
+         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
++        with:
++          ignore_names: update-to-head.sh
+
+   golangci:
+     name: lint


### PR DESCRIPTION
The shellcheck github action doesn't like some of the quoting we are using in update-to-head.sh so let's just skip that file when checking.