### PR TITLE
Changing Entrypoints on each docker image

### DIFF
--- a/redhat/overlays/Dockerfile.cloudsqlproxy
+++ b/redhat/overlays/Dockerfile.cloudsqlproxy
@@ -19,4 +19,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/cloudsqlproxy"]
+ENTRYPOINT ["cloudsqlproxy"]

--- a/redhat/overlays/Dockerfile.createcerts
+++ b/redhat/overlays/Dockerfile.createcerts
@@ -19,4 +19,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/createcerts"]
+ENTRYPOINT ["createcerts"]

--- a/redhat/overlays/Dockerfile.createctconfig
+++ b/redhat/overlays/Dockerfile.createctconfig
@@ -19,4 +19,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/createctconfig"]
+ENTRYPOINT ["createctconfig"]

--- a/redhat/overlays/Dockerfile.createdb
+++ b/redhat/overlays/Dockerfile.createdb
@@ -19,4 +19,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/createdb"]
+ENTRYPOINT ["createdb"]

--- a/redhat/overlays/Dockerfile.createtree
+++ b/redhat/overlays/Dockerfile.createtree
@@ -19,4 +19,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/createtree"]
+ENTRYPOINT ["createtree"]

--- a/redhat/overlays/Dockerfile.ct-server
+++ b/redhat/overlays/Dockerfile.ct-server
@@ -19,4 +19,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/ct_server"]
+ENTRYPOINT ["ct_server"]

--- a/redhat/overlays/Dockerfile.ctlog-managectroots
+++ b/redhat/overlays/Dockerfile.ctlog-managectroots
@@ -20,4 +20,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/managectroots"]
+ENTRYPOINT ["managectroots"]

--- a/redhat/overlays/Dockerfile.ctlog-verifyfulcio
+++ b/redhat/overlays/Dockerfile.ctlog-verifyfulcio
@@ -21,4 +21,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/verifyfulcio"]
+ENTRYPOINT ["verifyfulcio"]

--- a/redhat/overlays/Dockerfile.tuf-server
+++ b/redhat/overlays/Dockerfile.tuf-server
@@ -19,4 +19,4 @@ RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 WORKDIR ${HOME}
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/user/local/bin/tuf-server"]
+ENTRYPOINT ["tuf-server"]


### PR DESCRIPTION
After making an attempt to stand up these images in Openshift all failed to the Entrypoint Command being incorrect.

These changes do work as I have stood up the stack with all of these images, following this I signed and verifed a container image using cosign. 