### PR TITLE
SECURESIGN-115 | Add new label to dockerfiles for Comet

### DIFF
--- a/redhat/overlays/Dockerfile.cloudsqlproxy
+++ b/redhat/overlays/Dockerfile.cloudsqlproxy
@@ -23,6 +23,7 @@ LABEL io.k8s.description="Cloud SQL Proxy is a tool that makes connecting to Clo
 LABEL io.k8s.display-name="Cloud SQL Proxy container image for redhat trusted artifact signer."
 LABEL io.openshift.tags="cloudsqlproxy, Red Hat Trusted Artifact Signer."
 LABEL summary="Provides the binary for cloudsqlproxy."
+LABEL com.redhat.component="cloudsqlproxy"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["cloudsqlproxy"]

--- a/redhat/overlays/Dockerfile.createcerts
+++ b/redhat/overlays/Dockerfile.createcerts
@@ -23,6 +23,7 @@ LABEL io.k8s.description="The createcerts job creates a self-signed certificate,
 LABEL io.k8s.display-name="createcerts job container image for Red Hat trusted artifact signer."
 LABEL io.openshift.tags="createcerts, Red Hat trusted artifact signer."
 LABEL summary="Provides the createcerts binary."
+LABEL com.redhat.component="createcerts"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["createcerts"]

--- a/redhat/overlays/Dockerfile.createctconfig
+++ b/redhat/overlays/Dockerfile.createctconfig
@@ -23,6 +23,7 @@ LABEL io.k8s.description="The createctconfig job is responsible for configuring 
 LABEL io.k8s.display-name="createctconfig job container image for Red Hat Trusted Artifact Signer."
 LABEL io.openshift.tags="createctconfig, Red Hat trusted artifact signer."
 LABEL summary="Provides the createctconfig binary."
+LABEL com.redhat.component="createctconfig"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["createctconfig"]

--- a/redhat/overlays/Dockerfile.createdb
+++ b/redhat/overlays/Dockerfile.createdb
@@ -23,6 +23,7 @@ LABEL io.k8s.description="The createdb job is responsible for creating the MySQL
 LABEL io.k8s.display-name="createdb job container image for Red Hat Trusted Artifact Signer."
 LABEL io.openshift.tags="createdb, Red Hat trusted artifact signer."
 LABEL summary="Provides the createdb binary."
+LABEL com.redhat.component="createdb"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["createdb"]

--- a/redhat/overlays/Dockerfile.createtree
+++ b/redhat/overlays/Dockerfile.createtree
@@ -23,6 +23,7 @@ LABEL io.k8s.description="The createtree job is responsible for creating a Merkl
 LABEL io.k8s.display-name="createtree job container image for Red Hat Trusted Artifact Signer."
 LABEL io.openshift.tags="createtree, Red Hat trusted artifact signer."
 LABEL summary="Provides the createtree binary."
+LABEL com.redhat.component="createtree"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["createtree"]

--- a/redhat/overlays/Dockerfile.ct-server
+++ b/redhat/overlays/Dockerfile.ct-server
@@ -23,6 +23,7 @@ LABEL io.k8s.description="The binary responsible for providing the Certificate T
 LABEL io.k8s.display-name="CT server container image for Red Hat Trusted Artifact Signer."
 LABEL io.openshift.tags="CT-server, Red Hat trusted artifact signer."
 LABEL summary="Provides the CT-server binary."
+LABEL com.redhat.component="ct-server"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["ct_server"]

--- a/redhat/overlays/Dockerfile.ctlog-managectroots
+++ b/redhat/overlays/Dockerfile.ctlog-managectroots
@@ -24,6 +24,7 @@ LABEL io.k8s.description="The job responsible for managing the roots of the CT (
 LABEL io.k8s.display-name="managectroots job container image for Red Hat Trusted Artifact Signer."
 LABEL io.openshift.tags="managectroots, Red Hat trusted artifact signer."
 LABEL summary="Provides the binary for the managectroots job."
+LABEL com.redhat.component="ctlog-managectroots"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["managectroots"]

--- a/redhat/overlays/Dockerfile.ctlog-verifyfulcio
+++ b/redhat/overlays/Dockerfile.ctlog-verifyfulcio
@@ -25,6 +25,7 @@ LABEL io.k8s.description="The job responsible for verifying Fulcio."
 LABEL io.k8s.display-name="Fulcio verification job container image for Red Hat Trusted Artifact Signer."
 LABEL io.openshift.tags="verifyfulcio, Red Hat trusted artifact signer."
 LABEL summary="Provides the binary for verifyfulcio."
+LABEL com.redhat.component="ctlog-verifyfulcio"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["verifyfulcio"]

--- a/redhat/overlays/Dockerfile.tuf-server
+++ b/redhat/overlays/Dockerfile.tuf-server
@@ -23,6 +23,7 @@ LABEL io.k8s.description="Binary for the TUF (The Update Framework) server."
 LABEL io.k8s.display-name="TUF server container image for Red Hat Trusted Artifact Signer."
 LABEL io.openshift.tags="TUF-server, Red Hat trusted artifact signer."
 LABEL summary="Provides the TUF server binary."
+LABEL com.redhat.component="tuf-server"
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["tuf-server"]


### PR DESCRIPTION
This pr is related to this issue https://issues.redhat.com/browse/SECURESIGN-115, and involves adding an extra label to the Dockerfile for Comet.