### PR TITLE
chore: use  instead of  for build assets

### DIFF
--- a/redhat/release/update-to-head.sh
+++ b/redhat/release/update-to-head.sh
@@ -72,9 +72,9 @@ if [[ -d redhat/overlays ]]; then
   mv redhat/overlays/* .
 fi
 
-# Move build-assets to hack/build-assets
+# Copy build-assets to hack/build-assets
 if [[ -d redhat/build-assets ]]; then
-  mv redhat/build-assets/* hack/build-assets
+  cp -Rp redhat/build-assets/* hack/build-assets/
 fi
 
 git add . # Adds applied patches


### PR DESCRIPTION
The `mv` command will fail if anything within `redhat/build-assets` is a directory. This may need to be done eventually for the overlays directory as well as other components in the org.