### PR TITLE
chore: update to latest Red Hat UBI images

### DIFF
--- a/redhat/overlays/Dockerfile.cloudsqlproxy
+++ b/redhat/overlays/Dockerfile.cloudsqlproxy
@@ -1,5 +1,5 @@
 # Build the cloudsqlproxy binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 WORKDIR /cloudsqlproxy
 RUN git config --global --add safe.directory /cloudsqlproxy
 
@@ -8,7 +8,7 @@ USER root
 RUN make build-cloudsqlproxy
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /cloudsqlproxy/cloudsqlproxy /usr/local/bin/cloudsqlproxy
 RUN chown root:0 /usr/local/bin/cloudsqlproxy && chmod g+wx /usr/local/bin/cloudsqlproxy
 

--- a/redhat/overlays/Dockerfile.createcerts
+++ b/redhat/overlays/Dockerfile.createcerts
@@ -1,5 +1,5 @@
 # Build the createcerts binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 WORKDIR /createcerts
 RUN git config --global --add safe.directory /createcerts
 
@@ -8,7 +8,7 @@ USER root
 RUN make build-fulcio-createcerts
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /createcerts/createcerts /usr/local/bin/createcerts
 RUN chown root:0 /usr/local/bin/createcerts && chmod g+wx /usr/local/bin/createcerts
 

--- a/redhat/overlays/Dockerfile.createctconfig
+++ b/redhat/overlays/Dockerfile.createctconfig
@@ -1,5 +1,5 @@
 # Build the createctconfig binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 WORKDIR /createctconfig
 RUN git config --global --add safe.directory /createctconfig
 
@@ -8,7 +8,7 @@ USER root
 RUN make build-ctlog-createctconfig
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /createctconfig/createctconfig /usr/local/bin/createctconfig
 RUN chown root:0 /usr/local/bin/createctconfig && chmod g+wx /usr/local/bin/createctconfig
 

--- a/redhat/overlays/Dockerfile.createdb
+++ b/redhat/overlays/Dockerfile.createdb
@@ -1,5 +1,5 @@
 # Build the createdb binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 WORKDIR /createdb
 RUN git config --global --add safe.directory /createdb
 
@@ -8,7 +8,7 @@ USER root
 RUN make build-trillian-createdb
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /createdb/createdb /usr/local/bin/createdb
 RUN chown root:0 /usr/local/bin/createdb && chmod g+wx /usr/local/bin/createdb
 

--- a/redhat/overlays/Dockerfile.createtree
+++ b/redhat/overlays/Dockerfile.createtree
@@ -1,5 +1,5 @@
 # Build the createtree binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 WORKDIR /createtree
 RUN git config --global --add safe.directory /createtree
 
@@ -8,7 +8,7 @@ USER root
 RUN make build-trillian-createtree
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /createtree/createtree /usr/local/bin/createtree
 RUN chown root:0 /usr/local/bin/createtree && chmod g+wx /usr/local/bin/createtree
 

--- a/redhat/overlays/Dockerfile.ct-server
+++ b/redhat/overlays/Dockerfile.ct-server
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 USER root
 WORKDIR /ct_server
 RUN git config --global --add safe.directory /ct_server
@@ -8,7 +8,7 @@ WORKDIR /ct_server/certificate-transparency-go-1.1.6/trillian/ctfe/ct_server
 RUN go build ./
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /ct_server/certificate-transparency-go-1.1.6/trillian/ctfe/ct_server/ct_server /usr/local/bin/ct_server
 RUN chown root:0 /usr/local/bin/ct_server && chmod g+wx /usr/local/bin/ct_server
 

--- a/redhat/overlays/Dockerfile.ctlog-managectroots
+++ b/redhat/overlays/Dockerfile.ctlog-managectroots
@@ -1,5 +1,5 @@
 # Build the managectroots binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 WORKDIR /ctlog-managectroots
 RUN git config --global --add safe.directory /ctlog-managectroots
 
@@ -9,7 +9,7 @@ USER root
 RUN make build-ctlog-managectroots
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /ctlog-managectroots/managectroots /usr/local/bin/managectroots
 RUN chown root:0 /usr/local/bin/managectroots && chmod g+wx /usr/local/bin/managectroots
 

--- a/redhat/overlays/Dockerfile.ctlog-verifyfulcio
+++ b/redhat/overlays/Dockerfile.ctlog-verifyfulcio
@@ -1,5 +1,5 @@
 # Build the verifyfulcio binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 WORKDIR /ctlog-verifyfulcio
 RUN git config --global --add safe.directory /ctlog-verifyfulcio
 
@@ -9,7 +9,7 @@ USER root
 RUN make build-ctlog-verifyfulcio
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 
 COPY --from=build-env /ctlog-verifyfulcio/verifyfulcio /usr/local/bin/verifyfulcio
 RUN chown root:0 /usr/local/bin/verifyfulcio && chmod g+wx /usr/local/bin/verifyfulcio

--- a/redhat/overlays/Dockerfile.tuf-server
+++ b/redhat/overlays/Dockerfile.tuf-server
@@ -1,5 +1,5 @@
 # Build the tuf server binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:7e49e105a854749d67e5e02fb4069b48bd50445098c780b7f808cc351dee2589 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS build-env
 WORKDIR /tuf-server
 RUN git config --global --add safe.directory /tuf-server
 
@@ -8,7 +8,7 @@ USER root
 RUN make build-tuf-server
 
 # Install server
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:93d357bf8fae4a4965515898504d3c45b7421a56fc45fdd52651535a25af1023
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
 COPY --from=build-env /tuf-server/server /usr/local/bin/tuf-server
 RUN chown root:0 /usr/local/bin/tuf-server && chmod g+wx /usr/local/bin/tuf-server
 


### PR DESCRIPTION
Bumps both go-toolset and ubi-minimal for all images.

/cherry-pick midstream-v0.6.5