### PR TITLE
chore: remove unit tests from RHTAP pipeline

### DIFF
--- a/.tekton/cloudsqlproxy-pull-request.yaml
+++ b/.tekton/cloudsqlproxy-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/cloudsqlproxy-push.yaml
+++ b/.tekton/cloudsqlproxy-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/createcerts-pull-request.yaml
+++ b/.tekton/createcerts-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/createcerts-push.yaml
+++ b/.tekton/createcerts-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/createctconfig-pull-request.yaml
+++ b/.tekton/createctconfig-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/createctconfig-push.yaml
+++ b/.tekton/createctconfig-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/createdb-pull-request.yaml
+++ b/.tekton/createdb-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/createdb-push.yaml
+++ b/.tekton/createdb-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/createtree-pull-request.yaml
+++ b/.tekton/createtree-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/createtree-push.yaml
+++ b/.tekton/createtree-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/ct-server-pull-request.yaml
+++ b/.tekton/ct-server-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/ct-server-push.yaml
+++ b/.tekton/ct-server-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/ctlog-managectroots-pull-request.yaml
+++ b/.tekton/ctlog-managectroots-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/ctlog-managectroots-push.yaml
+++ b/.tekton/ctlog-managectroots-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/ctlog-verifyfulcio-pull-request.yaml
+++ b/.tekton/ctlog-verifyfulcio-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/ctlog-verifyfulcio-push.yaml
+++ b/.tekton/ctlog-verifyfulcio-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/tuf-server-pull-request.yaml
+++ b/.tekton/tuf-server-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/tuf-server-push.yaml
+++ b/.tekton/tuf-server-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/scaffolding-unit-test@sha256:8cdba586e2fbccb50351d9c04be1d2c1e846bf4c5b9203b4b32d57784d359140
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
As of today, custom tasks in RHTAP will fail as untrusted. This commit temporarily removes these tests from the pipelines.

See: https://issues.redhat.com/browse/EC-20