### PR TITLE
pipelines: add source image builds to all pipelines

### DIFF
--- a/.tekton/cloudsqlproxy-pull-request.yaml
+++ b/.tekton/cloudsqlproxy-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/cloudsqlproxy-push.yaml
+++ b/.tekton/cloudsqlproxy-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/createcerts-pull-request.yaml
+++ b/.tekton/createcerts-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/createcerts-push.yaml
+++ b/.tekton/createcerts-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/createctconfig-pull-request.yaml
+++ b/.tekton/createctconfig-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/createctconfig-push.yaml
+++ b/.tekton/createctconfig-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/createdb-pull-request.yaml
+++ b/.tekton/createdb-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/createdb-push.yaml
+++ b/.tekton/createdb-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/createtree-pull-request.yaml
+++ b/.tekton/createtree-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/createtree-push.yaml
+++ b/.tekton/createtree-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/ct-server-pull-request.yaml
+++ b/.tekton/ct-server-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: [{"path": ".", "type": "gomod"}, {"path": "./hack/build-assets", "type": "gomod"}]
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/ct-server-push.yaml
+++ b/.tekton/ct-server-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: [{"path": ".", "type": "gomod"}, {"path": "./hack/build-assets", "type": "gomod"}]
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/ctlog-managectroots-pull-request.yaml
+++ b/.tekton/ctlog-managectroots-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/ctlog-managectroots-push.yaml
+++ b/.tekton/ctlog-managectroots-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/ctlog-verifyfulcio-pull-request.yaml
+++ b/.tekton/ctlog-verifyfulcio-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/ctlog-verifyfulcio-push.yaml
+++ b/.tekton/ctlog-verifyfulcio-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/tuf-server-pull-request.yaml
+++ b/.tekton/tuf-server-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -117,6 +119,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -241,6 +247,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:

--- a/.tekton/tuf-server-push.yaml
+++ b/.tekton/tuf-server-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"path": ".", "type": "gomod"}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -114,6 +116,10 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+    - default: "false"
+      description: Build a source image
+      name: build-source-image
+      type: string
     results:
     - description: ""
       name: IMAGE_URL
@@ -238,6 +244,35 @@ spec:
         - "true"
       workspaces:
       - name: source
+        workspace: workspace
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: BASE_IMAGES
+        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: source-build
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:e751a76622743cf51b35ba230768be9886535b7cf51491c2b8513979e7a577d8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: workspace
         workspace: workspace
     - name: inspect-image
       params:


### PR DESCRIPTION
We are legally required to distribute the source for our OSS projects. Adding this task ensures compliance in the RHTAP build pipeline.