### PR TITLE
adding dockerfile for securesign-redis

### DIFF
--- a/Dockerfile.redis
+++ b/Dockerfile.redis
@@ -1,0 +1,15 @@
+FROM registry.redhat.io/rhel9/redis-6@sha256:031a5a63611e1e6a9fec47492a32347417263b79ad3b63bcee72fc7d02d64c94
+
+LABEL description="Securesign redis is built ontop of rhel9/redis-6 but accepts external connections and runs appendonly mode with full durability."
+LABEL io.k8s.description="Securesign redis is built ontop of rhel9/redis-6 but accepts external connections and runs appendonly mode with full durability."
+LABEL io.k8s.display-name="redis container image for Red Hat trusted artifact signer."
+LABEL io.openshift.tags="redis, Red Hat trusted artifact signer."
+LABEL summary="Runs redis in appendonly mode with enablement for external connections by default."
+LABEL com.redhat.component="redis"
+
+USER 1001
+
+RUN sed -i 's/#bind 127.0.0.1 -::1/bind 0.0.0.0/g' /etc/redis/redis.conf && sed -i 's/appendonly no/appendonly yes/g' /etc/redis/redis.conf
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-redis"]


### PR DESCRIPTION
I have documented the issue here: https://github.com/securesign/scaffolding/pull/124#issuecomment-1817595648.

To summarize:
- since we are using Redhat Certified redis, the arguments to `bind 0.0.0.0` and set `appendonly yes` cannot be passed in the same way we previously did for the `docker.io/redis` image.
    - `bind 0.0.0.0` allows it to recieve non local connections (outside container)
    - `appendonly yes`: see `APPEND ONLY MODE` section of config file in [redis docs](https://redis.io/docs/management/config-file/)
    
Proposing we add this to the component matrix. WDYT @lance 

Once this merges, the resulting image should be swapped in to the charts [here](https://github.com/securesign/sigstore-ocp/pull/88/files#diff-2d6b48a1bb9f1a6c85f004022e0b5c9917a2d5c48a39ae211407ce7ba27eb0a8R244-R246) for chart certification, [here](https://github.com/securesign/rekor/pull/159/files#diff-64f2866931c8f18669f8391a6f0a9dc45ec61d4291ea26eb3060f52d8b927392R30) and [here](https://github.com/securesign/rekor/pull/159/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R34)

This issue is a dependency of getting helm-charts certified (they can be certified as is but it makes them unstable).