### PR TITLE
Updated Release Script to support two inputs

### DIFF
--- a/redhat/release/update-to-head.sh
+++ b/redhat/release/update-to-head.sh
@@ -26,14 +26,14 @@
 #
 # Usage: update-to-head.sh [<git-ref>]
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -ne 2 ]; then
     upstream_ref="main"
     midstream_ref="main"
     redhat_ref="release-next"
 else
     upstream_ref=$1
-    midstream_ref="midstream-${upstream_ref}" # The overlays and patches for the given version
-    redhat_ref="redhat-${upstream_ref}" # The midstream repo with overlays and patches applied
+    midstream_ref="midstream-${2}" # The overlays and patches for the given version
+    redhat_ref="redhat-${2}" # The midstream repo with overlays and patches applied
 fi
 
 echo "Synchronizing ${redhat_ref} to upstream/${upstream_ref}..."


### PR DESCRIPTION
Since we are using just Major and Minor going forward the scripts for each of the repos will need a small change to accomodate this unless I am missing something!

For example
./redhat/release/update-to-head.sh "v0.6.9" "v0.6"

The first of the parameters pointing to the upstream ref and the second to our dev branch.