### PR TITLE
[SECURESIGN-210] chore: update base images for some components

### DIFF
--- a/Dockerfile.cloudsqlproxy
+++ b/Dockerfile.cloudsqlproxy
@@ -1,5 +1,5 @@
 # Build the cloudsqlproxy binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca AS build-env
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:98a0ff138c536eee98704d6909699ad5d0725a20573e2c510a60ef462b45cce0 AS build-env
 WORKDIR /cloudsqlproxy
 RUN git config --global --add safe.directory /cloudsqlproxy
 

--- a/Dockerfile.createdb
+++ b/Dockerfile.createdb
@@ -1,5 +1,5 @@
 # Build the createdb binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca AS build-env
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:98a0ff138c536eee98704d6909699ad5d0725a20573e2c510a60ef462b45cce0 AS build-env
 WORKDIR /createdb
 RUN git config --global --add safe.directory /createdb
 

--- a/Dockerfile.createtree
+++ b/Dockerfile.createtree
@@ -1,5 +1,5 @@
 # Build the createtree binary
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca AS build-env
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:98a0ff138c536eee98704d6909699ad5d0725a20573e2c510a60ef462b45cce0 AS build-env
 WORKDIR /createtree
 RUN git config --global --add safe.directory /createtree
 


### PR DESCRIPTION
This commit updates the base golang builder image for the cloudsqlproxy, createdb, and createtree components. This uses the OpenShift brew registry's Golang 1.21 builder. It is likely that all of the other Dockerfiles in this repo and in others for the RHTAS project will need to have their base images adjusted in the same way, and the github action for image sha updates should also include brew in its updates.

Fixes: https://issues.redhat.com/browse/SECURESIGN-210