### PR TITLE
fixing builds for create-certs

### DIFF
--- a/.tekton/createcerts-1-0-gamma-pull-request.yaml
+++ b/.tekton/createcerts-1-0-gamma-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "redhat-v0.6" && ( "cmd/fulcio/createcerts/*".pathChanged() || ".tekton/createcerts-*-pull-request.yaml".pathChanged() || "/Dockerfile.createcerts".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "config/fulcio/certs/*".pathChanged())
+      event == "push" && target_branch == "redhat-v0.6" && ( "cmd/fulcio/createcerts/***".pathChanged() || ".tekton/createcerts-1-0-gamma-pull-request.yaml".pathChanged() || "Dockerfile.createcerts".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "config/fulcio/certs/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: fulcio-1-0-gamma
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/devfile-samples/devfile-sample-go-basic/main/docker/Dockerfile
+    value: Dockerfile.createcerts
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
@@ -30,6 +30,12 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  - name: build-source-image
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/createcerts-1-0-gamma-push.yaml
+++ b/.tekton/createcerts-1-0-gamma-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "redhat-v0.6" && ( "cmd/fulcio/createcerts/*".pathChanged() || ".tekton/createcerts-*-push.yaml".pathChanged() || "/Dockerfile.createcerts".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "config/fulcio/certs/*".pathChanged() )
+      event == "push" && target_branch == "redhat-v0.6" && ( "cmd/fulcio/createcerts/***".pathChanged() || ".tekton/createcerts-1-0-gamma-push.yaml".pathChanged() || "Dockerfile.createcerts".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "config/fulcio/certs/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: fulcio-1-0-gamma
@@ -18,15 +18,23 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/devfile-samples/devfile-sample-go-basic/main/docker/Dockerfile
+    value: Dockerfile.createcerts
   - name: git-url
     value: '{{repo_url}}'
+  - name: image-expires-after
+    value: 5d
   - name: output-image
     value: quay.io/redhat-user-workloads/rhtas-tenant/fulcio-1-0-gamma/createcerts-1-0-gamma:{{revision}}
   - name: path-context
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  - name: build-source-image
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/createctconfig-0-6-pull-request.yaml
+++ b/.tekton/createctconfig-0-6-pull-request.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "redhat-v0.6"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "redhat-v0.6" && ( ".tekton/createctconfig-0-6-pull-request.yaml".pathChanged() || "Dockerfile.createctconfig".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "cmd/ctlog/createctconfig/***".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/scaffolding/redhat-v0.6/Dockerfile.createctconfig
+    value: Dockerfile.createctconfig
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
@@ -30,6 +30,12 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  - name: build-source-image
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/createctconfig-0-6-push.yaml
+++ b/.tekton/createctconfig-0-6-push.yaml
@@ -6,8 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "redhat-v0.6"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "redhat-v0.6" && ( ".tekton/createctconfig-0-6-push.yaml".pathChanged() || "Dockerfile.createctconfig".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "cmd/ctlog/createctconfig/***".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: https://raw.githubusercontent.com/securesign/scaffolding/redhat-v0.6/Dockerfile.createctconfig
+    value: Dockerfile.createctconfig
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image
@@ -27,6 +27,12 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  - name: build-source-image
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/redis-0-6-pull-request.yaml
+++ b/.tekton/redis-0-6-pull-request.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "redhat-v0.6"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "redhat-v0.6" && ( ".tekton/redis-0-6-pull-request.yaml".pathChanged() || "Dockerfile.redis".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma
@@ -30,6 +30,12 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  - name: build-source-image
+    value: "true"
+  - name: prefetch-input
+    value: '{}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/redis-0-6-push.yaml
+++ b/.tekton/redis-0-6-push.yaml
@@ -6,8 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "redhat-v0.6"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "redhat-v0.6" && ( ".tekton/redis-0-6-push.yaml".pathChanged() || "Dockerfile.redis".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma
@@ -27,6 +27,12 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  - name: build-source-image
+    value: "true"
+  - name: prefetch-input
+    value: '{}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/Dockerfile.createcerts
+++ b/Dockerfile.createcerts
@@ -1,12 +1,13 @@
 # Build the createcerts binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:98a0ff138c536eee98704d6909699ad5d0725a20573e2c510a60ef462b45cce0 AS build-env
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21@sha256:98a0ff138c536eee98704d6909699ad5d0725a20573e2c510a60ef462b45cce0 AS build-env
+USER root
+RUN mkdir /createcerts
 WORKDIR /createcerts
 RUN git config --global --add safe.directory /createcerts
 
 COPY . .
-USER root
-RUN go mod vendor
-RUN make build-fulcio-createcerts
+RUN CGO_ENABLED=0 go mod download
+RUN CGO_ENABLED=0 go build -o createcerts -mod=readonly -trimpath ./cmd/ctlog/createctconfig
 
 # Install server
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7d1ea7ac0c6f464dac7bae6994f1658172bf6068229f40778a513bc90f47e624


### PR DESCRIPTION
pinning tag and sha values for base image, swapping `go mod verdor `with `go mod download` for hermetic builds, also using `go.mod` dep source of truth