### PR TITLE
chore: update .tekton PR cel expressions

### DIFF
--- a/.tekton/createcerts-1-0-gamma-pull-request.yaml
+++ b/.tekton/createcerts-1-0-gamma-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "redhat-v0.6" && ( "cmd/fulcio/createcerts/***".pathChanged() || ".tekton/createcerts-1-0-gamma-pull-request.yaml".pathChanged() || "Dockerfile.createcerts".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "config/fulcio/certs/***".pathChanged())
+      event == "pull_request" && target_branch == "redhat-v0.6" && ( "cmd/fulcio/createcerts/***".pathChanged() || ".tekton/createcerts-1-0-gamma-pull-request.yaml".pathChanged() || "Dockerfile.createcerts".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "config/fulcio/certs/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: fulcio-1-0-gamma

--- a/.tekton/createcerts-1-0-gamma-pull-request.yaml
+++ b/.tekton/createcerts-1-0-gamma-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
-  - name: hermetic
-    value: "true"
   - name: build-source-image
     value: "true"
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/createcerts-1-0-gamma-push.yaml
+++ b/.tekton/createcerts-1-0-gamma-push.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
-  - name: hermetic
-    value: "true"
   - name: build-source-image
     value: "true"
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/createctconfig-0-6-pull-request.yaml
+++ b/.tekton/createctconfig-0-6-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "redhat-v0.6" && ( ".tekton/createctconfig-0-6-pull-request.yaml".pathChanged() || "Dockerfile.createctconfig".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "cmd/ctlog/createctconfig/***".pathChanged() )
+      event == "pull_request" && target_branch == "redhat-v0.6" && ( ".tekton/createctconfig-0-6-pull-request.yaml".pathChanged() || "Dockerfile.createctconfig".pathChanged() || "Makefile".pathChanged() || "go.mod".pathChanged() || "cmd/ctlog/createctconfig/***".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma

--- a/.tekton/createctconfig-0-6-pull-request.yaml
+++ b/.tekton/createctconfig-0-6-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
-  - name: hermetic
-    value: "true"
   - name: build-source-image
     value: "true"
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/createctconfig-0-6-push.yaml
+++ b/.tekton/createctconfig-0-6-push.yaml
@@ -27,12 +27,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
-  - name: hermetic
-    value: "true"
   - name: build-source-image
     value: "true"
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/createdb-0-6-pull-request.yaml
+++ b/.tekton/createdb-0-6-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "redhat-v0.6" && ( "cmd/trillian/createdb/*".pathChanged() || ".tekton/createdb-*-pull-request.yaml".pathChanged() || "/Dockerfile.createdb".pathChanged() || "config/trillian/createdb/*".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged()  )
+      event == "pull_request" && target_branch == "redhat-v0.6" && ( "cmd/trillian/createdb/*".pathChanged() || ".tekton/createdb-*-pull-request.yaml".pathChanged() || "Dockerfile.createdb".pathChanged() || "config/trillian/createdb/*".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged()  )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: trillian-1-0-gamma

--- a/.tekton/createtree-0-6-pull-request.yaml
+++ b/.tekton/createtree-0-6-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "redhat-v0.6" && ( "cmd/trillian/createtree/*".pathChanged() || ".tekton/createtree-*-pull-request.yaml".pathChanged() || "/Dockerfile.createtree".pathChanged() || "config/rekor/createtree/*".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged() )
+      event == "pull_request" && target_branch == "redhat-v0.6" && ( "cmd/trillian/createtree/*".pathChanged() || ".tekton/createtree-*-pull-request.yaml".pathChanged() || "Dockerfile.createtree".pathChanged() || "config/rekor/createtree/*".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: trillian-1-0-gamma

--- a/.tekton/ct-server-0-6-pull-request.yaml
+++ b/.tekton/ct-server-0-6-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "redhat-v0.6" && ( ".tekton/ct-server-*-pull-request.yaml".pathChanged() || "/Dockerfile.ct-server".pathChanged() || "hack/build-assets/*".pathChanged )
+      event == "pull_request" && target_branch == "redhat-v0.6" && ( ".tekton/ct-server-*-pull-request.yaml".pathChanged() || "Dockerfile.ct-server".pathChanged() || "hack/build-assets/*".pathChanged )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma

--- a/.tekton/ctlog-managectroots-0-6-pull-request.yaml
+++ b/.tekton/ctlog-managectroots-0-6-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull-request" && target_branch == "redhat-v0.6" && ( "cmd/ctlog/managectroots/*".pathChanged() || ".tekton/ctlog-managectroots-*-pull-request.yaml".pathChanged() || "/Dockerfile.ctlog-managectroots".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged() )
+      event == "pull-request" && target_branch == "redhat-v0.6" && ( "cmd/ctlog/managectroots/*".pathChanged() || ".tekton/ctlog-managectroots-*-pull-request.yaml".pathChanged() || "Dockerfile.ctlog-managectroots".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma

--- a/.tekton/ctlog-verify-fulcio-0-6-pull-request.yaml
+++ b/.tekton/ctlog-verify-fulcio-0-6-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "redhat-v0.6" && ( "config/fulcio/fulcio/*".pathChanged() || "cmd/ctlog/verifyfulcio/*".pathChanged() || ".tekton/ctlog-verify-fulcio-*-pull-request.yaml".pathChanged() || "/Dockerfile.ctlog-verifyfulcio".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged()  )
+      event == "pull_request" && target_branch == "redhat-v0.6" && ( "config/fulcio/fulcio/*".pathChanged() || "cmd/ctlog/verifyfulcio/*".pathChanged() || ".tekton/ctlog-verify-fulcio-*-pull-request.yaml".pathChanged() || "Dockerfile.ctlog-verifyfulcio".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged()  )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma

--- a/.tekton/redis-0-6-pull-request.yaml
+++ b/.tekton/redis-0-6-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "redhat-v0.6" && ( ".tekton/redis-0-6-pull-request.yaml".pathChanged() || "Dockerfile.redis".pathChanged() )
+      event == "pull_request" && target_branch == "redhat-v0.6" && ( ".tekton/redis-0-6-pull-request.yaml".pathChanged() || "Dockerfile.redis".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma

--- a/.tekton/tuf-server-0-6-pull-request.yaml
+++ b/.tekton/tuf-server-0-6-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "redhat-v0.6" && ( "cmd/tuf/server/*".pathChanged() || ".tekton/tuf-server-*-pull-request.yaml".pathChanged() || "/Dockerfile.tuf-server".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged() )
+      event == "pull_request" && target_branch == "redhat-v0.6" && ( "cmd/tuf/server/*".pathChanged() || ".tekton/tuf-server-*-pull-request.yaml".pathChanged() || "Dockerfile.tuf-server".pathChanged() || "go.mod".pathChanged() || "Makefile".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: scaffold-1-0-gamma


### PR DESCRIPTION
Some of the pipelines for pull requests had `push` as the triggering event instead of `pull_request`. Oddly, all of those components that had `pull_request` as the triggering event had a `/` prefix before the Dockerfile name trigger, which may have been causing those events not to be recognized.