### PR TITLE
Removing Expiration of images from on push

### DIFF
--- a/.tekton/createcerts-1-0-gamma-push.yaml
+++ b/.tekton/createcerts-1-0-gamma-push.yaml
@@ -20,8 +20,6 @@ spec:
     value: Dockerfile.createcerts
   - name: git-url
     value: '{{repo_url}}'
-  - name: image-expires-after
-    value: 5d
   - name: output-image
     value: quay.io/redhat-user-workloads/rhtas-tenant/fulcio-1-0-gamma/createcerts-1-0-gamma:{{revision}}
   - name: path-context


### PR DESCRIPTION
While going through our snapshot images I discovered that one of them was missing, the create certs, no other images were present recently on quay.io. This seems to be the culprit.